### PR TITLE
feat: add default export for compatibility with react-copy-to-clipboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,11 @@ yarn add react-copy-to-clipboard-ts
 ## Usage
 
 ```tsx
+// Named import (recommended)
 import { CopyToClipboard } from "react-copy-to-clipboard-ts";
+
+// Default import (for migration from react-copy-to-clipboard)
+import CopyToClipboard from "react-copy-to-clipboard-ts";
 
 function App() {
   return (

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,3 +48,6 @@ export const CopyToClipboard: React.FC<CopyToClipboardProps> = ({
   const elem = React.Children.only(children) as React.ReactElement<ChildProps>;
   return React.cloneElement(elem, { onClick, ...props });
 };
+
+// Default export for compatibility with the original react-copy-to-clipboard library
+export default CopyToClipboard;

--- a/test/CopyToClipboard.test.tsx
+++ b/test/CopyToClipboard.test.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { CopyToClipboard } from '../src';
+import CopyToClipboardDefault from '../src'; // Default import test
 
 // Mock copy-to-clipboard
 vi.mock('copy-to-clipboard', () => ({
@@ -17,7 +18,17 @@ describe('CopyToClipboard', () => {
       </CopyToClipboard>
     );
 
-    expect(screen.getByRole('button')).toHaveTextContent('Copy');
+    expect(screen.getByRole('button').textContent).toBe('Copy');
+  });
+
+  it('renders children correctly with default import', () => {
+    render(
+      <CopyToClipboardDefault text="test">
+        <button type="button">Copy Default</button>
+      </CopyToClipboardDefault>
+    );
+
+    expect(screen.getByRole('button').textContent).toBe('Copy Default');
   });
 
   it('calls onCopy when clicked', async () => {
@@ -26,6 +37,18 @@ describe('CopyToClipboard', () => {
       <CopyToClipboard text="test" onCopy={onCopy}>
         <button type="button">Copy</button>
       </CopyToClipboard>
+    );
+
+    await userEvent.click(screen.getByRole('button'));
+    expect(onCopy).toHaveBeenCalledWith('test', true);
+  });
+
+  it('calls onCopy when clicked (default import)', async () => {
+    const onCopy = vi.fn();
+    render(
+      <CopyToClipboardDefault text="test" onCopy={onCopy}>
+        <button type="button">Copy</button>
+      </CopyToClipboardDefault>
     );
 
     await userEvent.click(screen.getByRole('button'));
@@ -70,6 +93,10 @@ describe('CopyToClipboard', () => {
       </CopyToClipboard>
     );
 
-    expect(screen.getByTestId('test-button')).toBeInTheDocument();
+    expect(screen.getByTestId('test-button')).toBeDefined();
+  });
+
+  it('verifies named and default exports reference the same component', () => {
+    expect(CopyToClipboard).toBe(CopyToClipboardDefault);
   });
 });


### PR DESCRIPTION
- Add default export alongside existing named export
- Improve migration ease from original react-copy-to-clipboard library
- Add comprehensive tests for both import methods
- Update README with usage examples for both import styles
- Convert comments to English for better accessibility